### PR TITLE
improve release page with extra info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 
 # Temporary lock file while building
 /.hugo_build.lock
+

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,3 @@
+printWidth: 99
+semi: false
+trailingComma: "es5"

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,3 +1,4 @@
 printWidth: 99
 semi: false
 trailingComma: "es5"
+arrowParens: "avoid"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,23 +6,51 @@
     <div class="l-site">
       <div class="grid p-strip">
         <div class="row">
-          <div class="col-12">
+          <div class="col-8">
             <h2>Charm Engineering Releases</h2>
+          </div>
+          <div class="col-4 u-vertically-center u-align--right" style="grid-auto-flow: column">
+            <label class="p-switch">
+              <input type="checkbox" class="p-switch__input" role="switch" id="toggle-charms-only"/>
+              <span class="p-switch__slider"></span>
+              <span class="p-switch__label">Hide non-Charms</span>
+            </label>
+            <span>&emsp;</span>
+            <label class="p-switch">
+              <input type="checkbox" class="p-switch__input" role="switch" id="toggle-all-rows"/>
+              <span class="p-switch__slider"></span>
+              <span class="p-switch__label">Expand all rows</span>
+            </label>
+          </div> 
+        </div>
+        <div class="row">
+          <div class="col-12">
             <p class="u-no-max-width">
               This page catalogues releases from charm engineering teams. Its content automatically
               generated every 15 minutes by querying the Github API and scraping Launchpad pages.
               The data is generated using
               <a href="https://github.com/jnsgruk/releasegen">releasegen</a>.
             </p>
-            <p class="u-no-max-width">
-              For a release to show here, it must be part of one of the specified Github Teams or
-              Launchpad project groups. Github projects must have at least one Github Release,
-              Launchpad projects are scraped for tags. The latest three releases are shown for each
-              repository.
-            </p>
+            <aside class="p-accordion">
+              <ul class="p-accordion__list">
+                <li class="p-accordion__group">
+                  <div role="heading" aria-level="3" class="p-accordion__heading">
+                    <button type="button" class="p-accordion__tab" id="accordion-help-tab" aria-controls="accordion-help" aria-expanded="false">Need help getting your repository included here?</button>
+                  </div>
+                  <section class="p-accordion__panel" id="accordion-help" aria-hidden="true" aria-labelledby="accordion-help-tab">
+                    <p class="u-no-max-width"> For a release to show here, it must be part of one of the specified Github Teams or
+                    Launchpad project groups. Github projects must not be Archived, Launchpad projects are scraped for tags. The latest
+                    three releases are shown for each repository.</p>
+                    <p p class="u-no-max-width">For GitHub badges to be shown for your repository, add them in the README; similarly,
+                    to display the extra CharmHub release information in the expanding table rows, add the CharmHub badge
+                    ( <code>![](https://charmhub.io/*charm-name*/badge.svg)</code> ) to your charm's README.</p>
+                  </section>
+                </li>
+              </ul>
+            </aside>
           </div>
         </div>
-        <div class="row p-strip">
+        <div class="row p-strip is-shallow">
           <div class="p-tabs">
             <div class="p-tabs__list" role="tablist" aria-label="Charm teams">
               {{- range .Site.Data.repos -}}
@@ -49,6 +77,8 @@
       {{- partial "js/tabs.js" . | safeJS -}}
       {{- partial "js/modal.js" .  | safeJS -}}
       {{- partial "js/sortable.js" . | safeJS -}}
+      {{- partial "js/expand.js" . | safeJS -}}
+      {{- partial "js/accordion.js" . | safeJS -}}
     })();
   </script>
 </html>

--- a/layouts/partials/css/overrides.css
+++ b/layouts/partials/css/overrides.css
@@ -15,6 +15,22 @@ a.repo-name {
     font-weight: 400;
 }
 
+a.repo-icon {
+    color: #222;
+}
+
 [role=modal-open] {
     margin-right: 5px;
+}
+
+.inline-svg {
+    display: inline-block;
+    height: 1.15rem;
+    width: 1.15rem;
+    top: 0.15rem;
+    position: relative;
+}
+
+i.button-icon {
+    pointer-events: none;
 }

--- a/layouts/partials/js/accordion.js
+++ b/layouts/partials/js/accordion.js
@@ -1,0 +1,26 @@
+const toggleExpandedAccordion = (element, show) => {
+  const target = document.getElementById(element.getAttribute("aria-controls"))
+  if (target) {
+    element.setAttribute("aria-expanded", show)
+    target.setAttribute("aria-hidden", !show)
+  }
+}
+
+// Setup all accordions on the page.
+const accordions = document.querySelectorAll(".p-accordion")
+accordions.forEach(accordionContainer => {
+  // Set up an event listener on the container so that panels can be added
+  // and removed and events do not need to be managed separately.
+  accordionContainer.addEventListener("click", (event) => {
+    let target = event.target
+
+    if (target) {
+      if (target.closest) {
+        target = target.closest('[class*="p-accordion__tab"]')
+      }
+      const isTargetOpen = target.getAttribute("aria-expanded") === "true"
+      // Toggle visibility of the target panel.
+      toggleExpandedAccordion(target, !isTargetOpen)
+    }
+  })
+})

--- a/layouts/partials/js/accordion.js
+++ b/layouts/partials/js/accordion.js
@@ -11,7 +11,7 @@ const accordions = document.querySelectorAll(".p-accordion")
 accordions.forEach(accordionContainer => {
   // Set up an event listener on the container so that panels can be added
   // and removed and events do not need to be managed separately.
-  accordionContainer.addEventListener("click", (event) => {
+  accordionContainer.addEventListener("click", event => {
     let target = event.target
 
     if (target) {

--- a/layouts/partials/js/expand.js
+++ b/layouts/partials/js/expand.js
@@ -4,7 +4,7 @@ const toggleExpanded = (element, show) => {
     element.setAttribute("aria-expanded", show)
     // Adjust the text of the toggle button
     element.innerHTML = element.getAttribute(show ? "data-shown-text" : "data-hidden-text")
-    
+
     target.setAttribute("aria-hidden", !show)
   }
 }
@@ -17,7 +17,9 @@ const toggleButton = (element, active) => {
 
 // Add control to expand or collapse all rows at once
 const toggleAllButton = document.getElementById("toggle-all-rows")
-toggleAllButton.addEventListener("change", (event) => {
+toggleAllButton.addEventListener(
+  "change",
+  event => {
     const expandButtons = document.querySelectorAll(".charmhub-toggle")
     const target = event.target
     const isTargetActive = target.getAttribute("active") === "true"
@@ -34,7 +36,9 @@ toggleAllButton.addEventListener("change", (event) => {
 
 // Add control to only show charms in the table
 const toggleCharmsOnly = document.getElementById("toggle-charms-only")
-toggleCharmsOnly.addEventListener("change", (event) => {
+toggleCharmsOnly.addEventListener(
+  "change",
+  event => {
     const repositoryRows = document.querySelectorAll(".repository-row")
     const target = event.target
     const isTargetActive = target.getAttribute("active") === "true"
@@ -56,7 +60,7 @@ const tables = document.querySelectorAll(".p-table--expanding")
 tables.forEach(table => {
   // Set up an event listener on the container so that panels can be added
   // and removed and events do not need to be managed separately.
-  table.addEventListener("click", (event) => {
+  table.addEventListener("click", event => {
     const target = event.target
     const isTargetOpen = target.getAttribute("aria-expanded") === "true"
 

--- a/layouts/partials/js/expand.js
+++ b/layouts/partials/js/expand.js
@@ -1,0 +1,68 @@
+const toggleExpanded = (element, show) => {
+  const target = document.getElementById(element.getAttribute("aria-controls"))
+  if (target) {
+    element.setAttribute("aria-expanded", show)
+    // Adjust the text of the toggle button
+    element.innerHTML = element.getAttribute(show ? "data-shown-text" : "data-hidden-text")
+    
+    target.setAttribute("aria-hidden", !show)
+  }
+}
+
+// Adjust the text of the toggle button
+const toggleButton = (element, active) => {
+  element.setAttribute("active", active)
+  element.innerHTML = element.getAttribute(active ? "active-text" : "inactive-text")
+}
+
+// Add control to expand or collapse all rows at once
+const toggleAllButton = document.getElementById("toggle-all-rows")
+toggleAllButton.addEventListener("change", (event) => {
+    const expandButtons = document.querySelectorAll(".charmhub-toggle")
+    const target = event.target
+    const isTargetActive = target.getAttribute("active") === "true"
+    toggleButton(target, !isTargetActive)
+
+    expandButtons.forEach(b => {
+      if (!b.disabled) {
+        toggleExpanded(b, !isTargetActive)
+      }
+    })
+  },
+  false
+)
+
+// Add control to only show charms in the table
+const toggleCharmsOnly = document.getElementById("toggle-charms-only")
+toggleCharmsOnly.addEventListener("change", (event) => {
+    const repositoryRows = document.querySelectorAll(".repository-row")
+    const target = event.target
+    const isTargetActive = target.getAttribute("active") === "true"
+    // Adjust the text of the toggle button
+    toggleButton(target, !isTargetActive)
+
+    repositoryRows.forEach(r => {
+      isCharm = r.querySelector(".charmhub-table") !== null
+      if (!isCharm) {
+        r.style.display = r.style.display === "none" ? "" : "none"
+      }
+    })
+  },
+  false
+)
+
+// Setup all expandable tables on the page.
+const tables = document.querySelectorAll(".p-table--expanding")
+tables.forEach(table => {
+  // Set up an event listener on the container so that panels can be added
+  // and removed and events do not need to be managed separately.
+  table.addEventListener("click", (event) => {
+    const target = event.target
+    const isTargetOpen = target.getAttribute("aria-expanded") === "true"
+
+    if (target.classList.contains("u-toggle")) {
+      // Toggle visibility of the target panel.
+      toggleExpanded(target, !isTargetOpen)
+    }
+  })
+})

--- a/layouts/partials/js/modal.js
+++ b/layouts/partials/js/modal.js
@@ -1,12 +1,12 @@
-document.querySelectorAll("[role=modal-open]").forEach((btn) => {
-  btn.addEventListener("click", (event) => {
+document.querySelectorAll("[role=modal-open]").forEach(btn => {
+  btn.addEventListener("click", event => {
     const modalId = event.target.getAttribute("aria-controls")
     const modal = document.getElementById(modalId)
     modal.style.display = "flex"
   })
 })
-document.querySelectorAll("[role=modal-close]").forEach((btn) => {
-  btn.addEventListener("click", (event) => {
+document.querySelectorAll("[role=modal-close]").forEach(btn => {
+  btn.addEventListener("click", event => {
     const modalId = event.target.getAttribute("aria-controls")
     const modal = document.getElementById(modalId)
     modal.style.display = "none"

--- a/layouts/partials/js/sortable.js
+++ b/layouts/partials/js/sortable.js
@@ -1,11 +1,11 @@
 // Get the latest release time for a give project in the table
 const compareLastReleaseTime = (rowA, rowB, col) => {
-  const parse = (row) => row.cells[col].children[0].getAttribute("aria-release-date")
+  const parse = row => row.cells[col].children[0].getAttribute("aria-release-date")
   return parse(rowA) > parse(rowB)
 }
 
 const compareStatusBadgeContent = (rowA, rowB, col) => {
-  const parse = (row) => parseInt(row.cells[col].getAttribute("aria-new-commits"))
+  const parse = row => parseInt(row.cells[col].getAttribute("aria-new-commits"))
   return parse(rowA) > parse(rowB)
 }
 
@@ -19,7 +19,7 @@ const sortTable = (header, table) => {
   const newOrder = cur === 0 ? SORTABLE_STATES.ORDER[1] : SORTABLE_STATES.ORDER[0]
 
   // Reset all header sorts.
-  table.querySelectorAll("[aria-sort]").forEach((h) => h.setAttribute("aria-sort", ""))
+  table.querySelectorAll("[aria-sort]").forEach(h => h.setAttribute("aria-sort", ""))
   // Set the new header sort.
   header.setAttribute("aria-sort", newOrder)
 
@@ -48,13 +48,13 @@ const sortTable = (header, table) => {
     return contentA > contentB ? direction : -direction
   })
   // Append each row into the table, replacing the current elements.
-  newRows.forEach((row) => body.appendChild(row))
+  newRows.forEach(row => body.appendChild(row))
 }
 
-document.querySelectorAll("table").forEach((table) => {
+document.querySelectorAll("table").forEach(table => {
   // Setup all the tables to be sortable
   const rows = [...table.tBodies[0].rows]
   rows.forEach((r, i) => r.setAttribute("data-index", i))
   const headers = table.querySelectorAll("th[aria-sort]")
-  headers.forEach((h) => h.addEventListener("click", () => sortTable(h, table)))
+  headers.forEach(h => h.addEventListener("click", () => sortTable(h, table)))
 })

--- a/layouts/partials/js/tabs.js
+++ b/layouts/partials/js/tabs.js
@@ -1,10 +1,10 @@
-const getQueryParams = (key) => {
+const getQueryParams = key => {
   const usp = new URLSearchParams(window.location.search)
   return key ? usp.get(key) : usp
 }
 
 const setActiveTab = (tab, tabs) => {
-  tabs.forEach((tabElement) => {
+  tabs.forEach(tabElement => {
     const tabContent = document.getElementById(tabElement.getAttribute("aria-controls"))
 
     if (tabElement === tab) {
@@ -27,11 +27,11 @@ const setActiveTab = (tab, tabs) => {
 
 // Get the tab containers from the page
 const tabContainers = document.querySelectorAll('[role="tablist"]')
-tabContainers.forEach((tabContainer) => {
+tabContainers.forEach(tabContainer => {
   // Assign click / focus handlers for each of the tab buttons
   let tabs = tabContainer.querySelectorAll("[aria-controls]")
   tabs.forEach((tab, index) => {
-    tab.addEventListener("click", (e) => {
+    tab.addEventListener("click", e => {
       e.preventDefault()
       setActiveTab(tab, tabs)
     })

--- a/layouts/partials/modal.html
+++ b/layouts/partials/modal.html
@@ -2,12 +2,12 @@
   <section class="p-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="modal-title">
     <header class="p-modal__header">
       <h2 class="p-modal__title" id="modal-title">
-        {{ .repo.name }} - {{ .release.title }}
-        <a class="p-icon--external-link" href="{{ .release.url }}"></a>
+        {{ .repo.name }} - {{ .title }}
+        <a class="p-icon--external-link" href="{{ .url }}"></a>
       </h2>
       <button class="p-modal__close" aria-controls="{{- .id -}}" role="modal-close">Close</button>
     </header>
-    <div>{{ safeHTML (replace .release.body "h2" "h3") }}</div>
+    <div>{{ safeHTML (replace .body "h2" "h3") }}</div>
     <footer class="p-modal__footer">
       <button class="u-no-margin--bottom" aria-controls="{{ .id }}" role="modal-close">
         Cancel

--- a/layouts/partials/repo.html
+++ b/layouts/partials/repo.html
@@ -1,11 +1,12 @@
-<tr id="{{ .repo.name }}">
+<tr id="{{ .repo.name }}" class="repository-row">
   <td class="repository">
-    <a href="{{ .repo.url }}" class="repo-name">{{ .repo.name }}</a>
+    <a href="{{ .repo.url }}">{{ .repo.name }}</a>
   </td>
   <td class="release">
-    {{- range $release := .repo.releases -}} 
-      {{- $modal_id := printf "%s-%d" $.team.team (int $release.id) -}}
-      <p class="u-no-margin--bottom" aria-release-date="{{ $release.timestamp }}">
+    {{- if not (not .repo.releases) -}}
+      {{- range $release := .repo.releases -}}
+        {{- $modal_id := printf "%s-%d" $.team.team (int $release.id) -}}
+        <p class="u-no-margin--bottom" aria-release-date="{{ $release.timestamp }}">
         <small>
           <a class="p-icon--show" aria-controls="{{ $modal_id }}" role="modal-open"></a>
           <a href="{{ $release.url }}">{{ $release.version }}</a> on
@@ -13,11 +14,35 @@
             {{- (time (int $release.timestamp)).Format "Jan 2, 2006" -}}
           </time>
         </small>
-      </p>
-      {{- partial "modal" (dict "release" $release "repo" $.repo "team" $.team "id" $modal_id) -}} 
+        </p>
+        {{- partial "modal" (dict "title" $release.title "url" $release.url "body" $release.body "repo" $.repo "team" $.team "id" $modal_id) -}}
+      {{- end -}}
+    {{- else if not (not .repo.commits) -}}
+      {{- range $commit := .repo.commits -}}
+        {{- $modal_id := printf "%s-%s" $.team.team $commit.sha -}}
+        <p class="u-no-margin--bottom" aria-release-date="{{ $commit.timestamp }}">
+        <small>
+          <a class="p-icon--show" aria-controls="{{ $modal_id }}" role="modal-open"></a>
+          <a href="{{ $commit.url }}">{{ substr $commit.sha 0 7 }}</a> on
+          <time datetime="{{- int $commit.timestamp }}">
+            {{- (time (int $commit.timestamp)).Format "Jan 2, 2006" -}}
+          </time>
+        </small>
+        </p>
+        {{- partial "modal" (dict "title" (substr $commit.sha 0 7) "url" $commit.url "body" $commit.message "repo" $.repo "team" $.team "id" $modal_id) -}} 
+      {{- end -}}
     {{- end -}}
   </td>
-  <td class="u-align--right status" aria-new-commits="{{- .repo.new_commits }}">
+  <td class="u-align--center ciactions" {{- if eq (len (where .team.repos ".ci_actions" nil)) (len .team.repos) -}}aria-hidden="true"{{- end -}}>
+    {{- if not (not .repo.ci_actions) -}}
+      {{- range .repo.ci_actions -}}
+        <a href="{{- . -}}"><img src="{{- . -}}/badge.svg"></a>
+      {{- end -}}
+    {{- else -}}
+    <img src="https://img.shields.io/badge/CI%20Status-Unknown-lightgrey">
+    {{- end -}}
+  </td>
+  <td class="u-align--right status" aria-new-commits="{{- .repo.new_commits }}" style="max-width: 15%">
     {{- $n := int .repo.new_commits -}} 
     {{- if eq $n 0 -}}
       <div class="p-status-label--positive">Up to date</div>
@@ -30,6 +55,43 @@
         </a>
       </div>
     {{- end -}}
+  </td>
+  <td class="u-align--right showmore" style="max-width: 10%" {{- if eq (len (where .team.repos ".charm" nil)) (len .team.repos) -}}aria-hidden="true"{{- end -}}>
+    <button class="p-button--base u-toggle is-dense is-inline charmhub-toggle" aria-controls="expanded-row-{{- .repo.name -}}" aria-expanded="false" data-shown-text="<i class='button-icon p-icon--chevron-up'></i>" data-hidden-text="<i class='button-icon p-icon--chevron-down'></i>" {{ cond (not (not .repo.charm)) "" "disabled" }}><i class="button-icon p-icon--chevron-down"></i></button>
+  </td>
+  <td id="expanded-row-{{- .repo.name -}}" class="p-table__expanding-panel" aria-hidden="true">
+    <div class="row">
+      <div class="col">
+        {{- if not (not .repo.charm) -}}
+        <table class="charmhub-table">
+          <thead>
+            <tr>
+              <th>CharmHub Track</th>
+              {{- range $channel := .repo.charm.channels -}}
+              <th>{{- $channel -}}</th>
+              {{- end -}}
+            </tr>
+          </thead>
+          <tbody>
+            {{- range $track := $.repo.charm.tracks -}}
+              <tr>
+                <td><b>{{- $track -}}</b></td>
+                {{- range $channel := $.repo.charm.channels -}}
+                  {{- $releasesForTrack := where $.repo.charm.releases "track" $track -}}
+                  {{- $release := index (where $releasesForTrack "channel" $channel) 0 -}}
+                  {{- if not (not $release) -}}
+                    <td><a href="{{- $.repo.charm.url -}}?channel={{- $track -}}/{{- $channel -}}">{{- $release.revision -}}</a><br><sup>{{- (time (int $release.timestamp)).Format "Jan 2, 2006" -}}</sup></td>
+                  {{- else -}}
+                    <td></td>
+                  {{- end -}}
+                {{- end -}}
+              </tr>
+            {{- end -}}
+          </tbody>
+        </table>
+        {{- end -}}
+      </div>
+    </div>
   </td>
 </tr>
 

--- a/layouts/partials/team-table.html
+++ b/layouts/partials/team-table.html
@@ -1,9 +1,12 @@
-<table class="releases">
+<table class="p-table--expanding releases">
   <thead>
     <tr>
       <th aria-sort="" class="repository">Repository</th>
-      <th aria-sort="ascending" class="release">Latest Releases</th>
-      <th aria-sort="" class="u-align--right status">Commits Since</th>
+      <th aria-sort="ascending" class="release">Latest Releases/Commit</th>
+      <th class="u-align--center ciactions" {{- if eq (len (where .team.repos ".ci_actions" nil)) (len .team.repos) -}}aria-hidden="true"{{- end -}}>Status</th>
+      <th aria-sort="" class="u-align--right status" style="max-width: 15%">Commits Since</th>
+      <th class="u-align--right showmore" style="max-width: 10%" {{- if eq (len (where .team.repos ".charm" nil)) (len .team.repos) -}}aria-hidden="true"{{- end -}}><i class="p-icon--information"></i>&emsp;&nbsp;&nbsp;</th>
+      <th aria-hidden="true"><!-- cell for expandable rows --></th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
## Summary

The current status page at https://releases.juju.is/ could be enriched with extra useful data. This PR aims to improve the page with CI and CharmHub information, to make it a more accurate representation of the team's repositories and a better self-monitoring tool.

Here you can see a preview of the changes being proposed, going from:
![01](https://user-images.githubusercontent.com/36242061/217198968-99507bbd-5b3c-4f13-82ff-0600dd39b47b.png)
to:
![04](https://user-images.githubusercontent.com/36242061/217199064-ba18e064-f4d4-4902-b25b-a6ab03cb8938.png)
(the images' purpose is to show how the information would be structured)

## Changes Details

### What it would add

This PR introduces two main additions: CI status and CharmHub releases.

The current prototype presents the CI information in line with the rest; this doesn't thicken the row (because of the "Latest Releases") and allows teams to monitor their repositories more effectively.

The CharmHub releases would be displayed in a collapsible row, to avoid cluttering the screen, and show the current revision for each release track and channel, together with its release date. This information can be critical when multiple charms need to be promoted from `edge` to `stable`, as it allows monitoring the promotion status across all repositories (which is currently not possible anywhere else).  

### How it would happen

The releases page includes a wide variety of repositories: some are charms, some run CIs, some are more bare-bones. Moreover, different teams can use different nomenclatures for CI steps and release channels; it's not possible to know a priori which CI is relevant and which isn't.

The idea is to have the teams "opt-in" by adding the CI badges in each README.md; [releasegen](https://github.com/jnsgruk/releasegen) will then scrape the README.md of each project and visualize the status of those steps only.  
CharmHub releases would follow a similar approach; to show them in the page, the README.md should contain the CharmHub badge (found at `https://charmhub.io/<charm-name>/badge.svg`)
This way, the repository maintainers can have more control on this process, and we can avoid to "automatically detect" a charm through different repository structures and nomenclatures. If the badge is not found in the README.md, the button would be disabled.

### releasegen

It's clear that the data received by this repo will need to be adjusted for this use case; I'll open a PR for that soon and link it here.  

## Final Notes

Any comment or suggestion is very welcome!