### PR TITLE
add filter text box

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,11 +10,11 @@
             <h2>Charm Engineering Releases</h2>
           </div>
           <div class="col-4 u-vertically-center u-align--right" style="grid-auto-flow: column">
-            <label class="p-switch">
-              <input type="checkbox" class="p-switch__input" role="switch" id="toggle-charms-only"/>
-              <span class="p-switch__slider"></span>
-              <span class="p-switch__label">Hide non-Charms</span>
-            </label>
+            <div class="p-search-and-filter">
+              <div class="p-search-and-filter__search-container" aria-expanded="false" data-active="true" data-empty="true">
+                  <input autocomplete="off" class="p-search-and-filter__input" id="table-filter-textbox" placeholder="Filter repositories" type="search" value="">
+                </div>
+            </div>
             <span>&emsp;</span>
             <label class="p-switch">
               <input type="checkbox" class="p-switch__input" role="switch" id="toggle-all-rows"/>

--- a/layouts/partials/js/expand.js
+++ b/layouts/partials/js/expand.js
@@ -47,8 +47,7 @@ tableFilterTextbox.addEventListener(
 
     repositoryRows.forEach(r => {
       const repoName = r.querySelector(".repository-link").textContent
-      const isSelected = regexp.test(repoName)
-      r.style.display = isSelected ? "" : "none"
+      r.style.display = regexp.test(repoName) ? "" : "none"
     })
   },
   false

--- a/layouts/partials/js/expand.js
+++ b/layouts/partials/js/expand.js
@@ -34,22 +34,21 @@ toggleAllButton.addEventListener(
   false
 )
 
-// Add control to only show charms in the table
-const toggleCharmsOnly = document.getElementById("toggle-charms-only")
-toggleCharmsOnly.addEventListener(
-  "change",
+// Add textbox to filter repositories
+const tableFilterTextbox = document.getElementById("table-filter-textbox")
+tableFilterTextbox.addEventListener(
+  "input",
   event => {
+    const text = event.target.value
     const repositoryRows = document.querySelectorAll(".repository-row")
-    const target = event.target
-    const isTargetActive = target.getAttribute("active") === "true"
-    // Adjust the text of the toggle button
-    toggleButton(target, !isTargetActive)
+
+    // Escape special regex symbols except '|' to specify ORs
+    const regexp = new RegExp(text.toLowerCase().replace(/[.*+?^${}()[\]\\]/g, "\\$&"))
 
     repositoryRows.forEach(r => {
-      isCharm = r.querySelector(".charmhub-table") !== null
-      if (!isCharm) {
-        r.style.display = r.style.display === "none" ? "" : "none"
-      }
+      const repoName = r.querySelector(".repository-link").textContent
+      const isSelected = regexp.test(repoName)
+      r.style.display = isSelected ? "" : "none"
     })
   },
   false

--- a/layouts/partials/repo.html
+++ b/layouts/partials/repo.html
@@ -1,6 +1,6 @@
 <tr id="{{ .repo.name }}" class="repository-row">
   <td class="repository">
-    <a href="{{ .repo.url }}">{{ .repo.name }}</a>
+    <a class="repository-link "href="{{ .repo.url }}">{{ .repo.name }}</a>
   </td>
   <td class="release">
     {{- if not (not .repo.releases) -}}


### PR DESCRIPTION
It would be nice to have a filtering text box for the following use cases:
* only show repos that relate to a certain component (`Search: loki` to show all Loki-related projects)
* only show repos holding certain things (`Search: rock` to show all ROCKs, `Search: operator|bundle` to show all charms and bundles)
* 
The bar would replace the "Hide non-Charms" switch, as it would fit the same purpose and expand its capabilities.

The search supports the `|` operator (as `OR`).