### PR TITLE
feat: Adds TLS team

### DIFF
--- a/releasegen.yaml
+++ b/releasegen.yaml
@@ -39,6 +39,12 @@ teams:
         teams:
           - telco
 
+  - name: TLS
+    github:
+      - org: canonical
+        teams:
+          - tls
+
   - name: Data Platform
     github:
       - org: canonical


### PR DESCRIPTION
## Description
Adds a new column for the TLS team

## Rationale
We are separating the existing Telco team and projects in two: Telco and TLS. Everything TLS related (`manual-tls-certificates`, `self-signed-certificates`, `vault-k8s`, ACME operators, etc. are being moved to the TLS team in Github. 