### PR TITLE
Update bootstack to solutions engineering team

### DIFF
--- a/releasegen.yaml
+++ b/releasegen.yaml
@@ -78,14 +78,12 @@ teams:
       project-groups:
         - is-charms
 
-  - name: BootStack
+  - name: Solutions Engineering
     github:
       - org: canonical
         teams:
-          - bootstack
+          - solutions-engineering
         ignores:
           - bootstack-actions
-          - cannon
-          - charmed-openstack-upgrader
-          - doc-docs
-          - cloudstats
+          - solutions-engineering-automation
+          - snap-tempest-automation


### PR DESCRIPTION
Update the "BootStack" team name to "Solutions Engineering". 
https://github.com/orgs/canonical/teams/solutions-engineering/