### PR TITLE
Fix HTML typo: remove duplicate 'p' in paragraph tag

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -68,7 +68,7 @@
                     Launchpad projects are scraped for tags. The latest three releases are shown
                     for each repository.
                   </p>
-                  <p p class="u-no-max-width">
+                  <p class="u-no-max-width">
                     For GitHub badges to be shown for your repository, add them in the README;
                     similarly, to display the extra CharmHub release information in the expanding
                     table rows, add the CharmHub badge (


### PR DESCRIPTION
This PR fixes a minor HTML syntax error in layouts/index.html where a paragraph tag had a duplicate p attribute.