### PR TITLE
chore: Rename Data Platform team

### DIFF
--- a/releasegen.yaml
+++ b/releasegen.yaml
@@ -46,7 +46,7 @@ teams:
     github:
       - org: canonical
         teams:
-          - data-ai-admins
+          - data-admins
 
   - name: ROCKs
     github:


### PR DESCRIPTION
The name of the Data Platform team was invalid (`data-ai-admins`).
The correct name is `data-admins` (check [here](https://github.com/orgs/canonical/teams/data-admins)).

This PR restores the correct name to restore the releases dashboard.