### PR TITLE
chore: bump releasegen version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           hugo --minify
         env:
           RELEASEGEN_TOKEN: ${{ secrets.API_TOKEN }}
-          RELEASEGEN_VERSION: "0.5.2"
+          RELEASEGEN_VERSION: "0.6.0"
 
       - name: Commit changes to data file
         run: |


### PR DESCRIPTION
=> Enables pagination of github api to report all repositories for all teams.